### PR TITLE
Add a query command

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1,8 +1,10 @@
 import asyncio
 from configparser import ConfigParser
+import typing
 from dotenv import load_dotenv
 import os
 
+import discord
 from discord.ext import commands
 
 from pymongo import MongoClient, database
@@ -138,6 +140,25 @@ async def verify_user(ctx):
             await ctx.send(
                 f"Sorry <@{user_id}>, could not auto-detect your verification. Please run `.verify` again."
             )
+
+
+def is_academic(ctx: commands.Context):
+    return get_config(str(ctx.guild.id)).get("is_academic", False)
+
+
+@bot.command(name="query")
+@commands.check(is_academic)
+async def query(
+    ctx: commands.Context,
+    identifier: discord.User,
+):
+    user = db.users.find_one({"discordId": identifier.id})
+    if user:
+        ctx.reply(
+            f"Name: {user['name']}\nEmail: {user['email']}\nRoll Number: {user['rollno']}"
+        )
+    else:
+        ctx.reply(f"{identifier} is not registered with IIIT-CAS.")
 
 
 @bot.event


### PR DESCRIPTION
NOT TESTED

Parameters: [Roll number|Email|discord user] [which property to query]

Should currently be able to get the name/rollnumber/email.

No testing was done. I'm too lazy to set up a testing env right now. Maybe some time later.

`bonsai` needs to be installed in the env of the bot to be able to query LDAP.

2 new ENV_VARS:
 - `LDAP_HOST`: Self explanatory. should be `ldap://ldap.iiit.ac.in` for IIITH
 - `LDAP_BASE`: Self explanatory. should be `dc=iiit,dc=ac,dc=in` for IIITH