### PR TITLE
Don't use absolute paths for redirects.

### DIFF
--- a/portal/app.js
+++ b/portal/app.js
@@ -37,7 +37,7 @@ app.get('/test', (req, res) => {
 });
 
 app.get('/', (req, res) => {
-    res.redirect('/discord');
+    res.redirect('discord');
 });
 
 app.get('/discord', (req, res) => {
@@ -104,7 +104,7 @@ app.get('/discord/callback', async (req, res) => {
 
     req.session.discordId = user.id;
 
-    res.redirect('/cas');
+    res.redirect('../cas');
 })
 
 const CAS = require('cas')


### PR DESCRIPTION
So that we can do simple redirects from the webserver.

Right now, for bot hosted on subpath, we're using the webserver to
rewrite requests when passing it to the reverse proxy. we can do the
same for the respose also, but this seemed better.

Instead of rewriting at all, we can use a Router and use that to move
all endpoints to a specific subpath, but then the config gets muddy.

Going with this, for now.